### PR TITLE
SNL VRL dumper option to dump multiple files

### DIFF
--- a/src/snl/formats/verilog/backend/SNLVRLDumper.cpp
+++ b/src/snl/formats/verilog/backend/SNLVRLDumper.cpp
@@ -351,7 +351,6 @@ void SNLVRLDumper::dumpDesign(const SNLDesign* design, const std::filesystem::pa
     streamDumper.setConfiguration(configuration);
     SNLUtils::SortedDesigns designs;
     SNLUtils::getDesignsSortedByHierarchicalLevel(design, designs);
-    bool first = true;
     for (auto designLevel: designs) {
       const SNLDesign* design = designLevel.first;
       std::filesystem::path filePath = path/getTopFileName(design);

--- a/src/snl/formats/verilog/backend/SNLVRLDumper.cpp
+++ b/src/snl/formats/verilog/backend/SNLVRLDumper.cpp
@@ -18,6 +18,8 @@
 
 #include <cassert>
 #include <algorithm>
+#include <sstream>
+#include <fstream>
 
 #include "SNLLibrary.h"
 #include "SNLDesign.h"
@@ -49,6 +51,18 @@ void dumpDirection(const naja::SNL::SNLTerm* term, std::ostream& o) {
 }
 
 namespace naja { namespace SNL {
+
+void SNLVRLDumper::setSingleFile(bool mode) {
+  configuration_.setSingleFile(mode);
+}
+
+void SNLVRLDumper::setTopFileName(const std::string& name) {
+  configuration_.setTopFileName(name);
+}
+
+void SNLVRLDumper::setDumpHierarchy(bool mode) {
+  configuration_.setDumpHierarchy(mode);
+}
 
 std::string SNLVRLDumper::createDesignName(const SNLDesign* design) {
   auto library = design->getLibrary();
@@ -285,16 +299,66 @@ void SNLVRLDumper::dumpOneDesign(const SNLDesign* design, std::ostream& o) {
 }
 
 void SNLVRLDumper::dumpDesign(const SNLDesign* design, std::ostream& o) {
-  SNLUtils::SortedDesigns designs;
-  SNLUtils::getDesignsSortedByHierarchicalLevel(design, designs);
-  bool first = true;
-  for (auto designLevel: designs) {
-    const SNLDesign* design = designLevel.first;
-    if (not first) {
-      o << std::endl;
+  if (configuration_.isDumpHierarchy()) {
+    SNLUtils::SortedDesigns designs;
+    SNLUtils::getDesignsSortedByHierarchicalLevel(design, designs);
+    bool first = true;
+    for (auto designLevel: designs) {
+      const SNLDesign* design = designLevel.first;
+      if (not first) {
+        o << std::endl;
+      }
+      first = false;
+      dumpOneDesign(design, o);
     }
-    first = false;
+  } else {
     dumpOneDesign(design, o);
+  }
+}
+
+std::string SNLVRLDumper::getTopFileName(const SNLDesign* top) const {
+  if (configuration_.hasTopFileName()) {
+    return configuration_.getTopFileName() + ".v";
+  }
+  if (not top->isAnonymous()) {
+    return top->getName().getString() + ".v";
+  }
+  return "top.v";
+} 
+
+void SNLVRLDumper::dumpDesign(const SNLDesign* design, const std::filesystem::path& path) {
+  if (not std::filesystem::exists(path)) {
+    std::ostringstream reason;
+    if (not design->isAnonymous()) {
+      reason << design->getName().getString();
+    } else {
+      reason << "anonymous design";
+    }
+    reason << " cannot be dumped: ";
+    reason << path.string() << " " << " does not exist";
+    throw SNLVRLDumperException(reason.str());
+  }
+  if (configuration_.isSingleFile()) {
+    //create file
+    std::filesystem::path filePath = path/getTopFileName(design);
+    std::ofstream outFile;
+    outFile.open(filePath);
+    dumpDesign(design, outFile);
+  } else {
+    SNLVRLDumper streamDumper;
+    SNLVRLDumper::Configuration configuration(configuration_);
+    configuration.setDumpHierarchy(false);
+    streamDumper.setConfiguration(configuration);
+    SNLUtils::SortedDesigns designs;
+    SNLUtils::getDesignsSortedByHierarchicalLevel(design, designs);
+    bool first = true;
+    for (auto designLevel: designs) {
+      const SNLDesign* design = designLevel.first;
+      std::filesystem::path filePath = path/getTopFileName(design);
+      std::ofstream outFile;
+      outFile.open(filePath);
+      streamDumper.dumpDesign(design, outFile);
+    }
   }
 }
 

--- a/test/snl/formats/verilog/backend/CMakeLists.txt
+++ b/test/snl/formats/verilog/backend/CMakeLists.txt
@@ -4,6 +4,7 @@ set(snl_vrl_tests SNLVRLDumperTest0.cpp)
 
 add_executable(snlVRLTests ${snl_vrl_tests})
 
+target_compile_definitions(snlVRLTests PRIVATE SNL_VRL_DUMPER_TEST_PATH="${CMAKE_CURRENT_BINARY_DIR}")
 target_link_libraries(snlVRLTests naja_snl_verilog gtest gtest_main)
 
 GTEST_DISCOVER_TESTS(snlVRLTests)

--- a/test/snl/formats/verilog/backend/SNLVRLDumperTest0.cpp
+++ b/test/snl/formats/verilog/backend/SNLVRLDumperTest0.cpp
@@ -15,6 +15,10 @@
 
 using namespace naja::SNL;
 
+#ifndef SNL_VRL_DUMPER_TEST_PATH
+#define SNL_VRL_DUMPER_TEST_PATH "Undefined"
+#endif
+
 class SNLVRLDumperTest0: public ::testing::Test {
   protected:
     void SetUp() override {
@@ -48,14 +52,46 @@ class SNLVRLDumperTest0: public ::testing::Test {
     SNLDB*      db_;
 };
 
-TEST_F(SNLVRLDumperTest0, test0) {
+TEST_F(SNLVRLDumperTest0, testNonExistingPath) {
   auto lib = db_->getLibrary(SNLName("MYLIB"));  
   ASSERT_TRUE(lib);
   auto top = lib->getDesign(SNLName("design"));
   ASSERT_TRUE(top);
-  std::filesystem::path outPath("test.v");
-  std::ofstream ofs(outPath, std::ofstream::out);
+  std::filesystem::path outPath(SNL_VRL_DUMPER_TEST_PATH);
+  outPath = outPath / "ERROR";
   SNLVRLDumper dumper;
-  dumper.dumpDesign(top, ofs);
-  ofs.close();
+  ASSERT_THROW(dumper.dumpDesign(top, outPath), SNLVRLDumperException);
+}
+
+TEST_F(SNLVRLDumperTest0, testSingleFile) {
+  auto lib = db_->getLibrary(SNLName("MYLIB"));  
+  ASSERT_TRUE(lib);
+  auto top = lib->getDesign(SNLName("design"));
+  ASSERT_TRUE(top);
+  std::filesystem::path outPath(SNL_VRL_DUMPER_TEST_PATH);
+  outPath = outPath / "test0SingleFile";
+  if (std::filesystem::exists(outPath)) {
+    std::filesystem::remove_all(outPath);
+  }
+  std::filesystem::create_directory(outPath);
+  SNLVRLDumper dumper;
+  dumper.setTopFileName(top->getName().getString());
+  dumper.setSingleFile(true);
+  dumper.dumpDesign(top, outPath);
+}
+
+TEST_F(SNLVRLDumperTest0, testMultipleFiles) {
+  auto lib = db_->getLibrary(SNLName("MYLIB"));  
+  ASSERT_TRUE(lib);
+  auto top = lib->getDesign(SNLName("design"));
+  ASSERT_TRUE(top);
+  std::filesystem::path outPath(SNL_VRL_DUMPER_TEST_PATH);
+  outPath = outPath / "test0MultipleFiles";
+  if (std::filesystem::exists(outPath)) {
+    std::filesystem::remove_all(outPath);
+  }
+  std::filesystem::create_directory(outPath);
+  SNLVRLDumper dumper;
+  dumper.setSingleFile(false);
+  dumper.dumpDesign(top, outPath);
 }


### PR DESCRIPTION
Add an option in Verilog dumper allowing to generate one file per design of the hierarchy.