### PR TITLE
Fix bug in verilog dumper

### DIFF
--- a/src/snl/formats/verilog/backend/SNLVRLDumper.cpp
+++ b/src/snl/formats/verilog/backend/SNLVRLDumper.cpp
@@ -205,6 +205,12 @@ void SNLVRLDumper::dumpInsTermConnectivity(
         if (dynamic_cast<SNLScalarNet*>(net)) {
           dumpRange(contiguousBits, firstElement, concatenation, connectionStr);
           SNLName netName = getNetName(net, naming);
+          if (not firstElement) {
+            connectionStr += ", ";
+            concatenation = true;
+          } else {
+            firstElement = false;
+          }
           connectionStr += netName.getString();
         } else {
           auto busNetBit = static_cast<SNLBusNetBit*>(net);

--- a/src/snl/snl/kernel/SNLInstance.cpp
+++ b/src/snl/snl/kernel/SNLInstance.cpp
@@ -110,7 +110,10 @@ void SNLInstance::removeInstTerm(SNLBitTerm* term) {
 
 void SNLInstance::setTermsNets(const Terms& terms, const Nets& nets) {
   if (terms.size() not_eq nets.size()) {
-    throw SNLException("setTermsNets error incompatible size between terms and nets");
+    std::ostringstream reason;
+    reason << "setTermsNets only supported when terms (size: " << terms.size() << ")"
+      << " and nets share same size (size: " << nets.size() << ")";
+    throw SNLException(reason.str());
   }
   for (size_t i=0; i<terms.size(); ++i) {
     SNLBitTerm* bitTerm = terms[i];
@@ -163,7 +166,10 @@ void SNLInstance::setTermNet(
 
 void SNLInstance::setTermNet(SNLTerm* term, SNLNet* net) {
   if (term->getSize() not_eq net->getSize()) {
-    throw SNLException("setTermNet only supported when term and net share same size");
+    std::ostringstream reason;
+    reason << "setTermNet only supported when term (size: " << term->getSize() << ")"
+      << " and net share same size (size: " << net->getSize() << ")";
+    throw SNLException(reason.str());
   }
   Terms terms;
   Nets nets;

--- a/test/snl/formats/verilog/backend/references/test1Test3/top.v
+++ b/test/snl/formats/verilog/backend/references/test1Test3/top.v
@@ -1,0 +1,18 @@
+module model(input [2:-2] i0, input [-2:2] i1, output [2:-2] o0, output [-2:2] o1);
+endmodule //model
+
+module top();
+wire [2:-2] bus0;
+wire [-2:2] bus1;
+wire [2:-2] bus2;
+wire [-2:2] bus3;
+wire net_0;
+wire net_1;
+wire net_2;
+wire net_3;
+wire net_4;
+
+model instance1(.i0(), .i1(), .o0({net_0, net_1, net_2, net_3, net_4}), .o1());
+
+model instance2(.i0(), .i1(), .o0(), .o1());
+endmodule //top

--- a/test/snl/formats/verilog/backend/references/test1Test4/top.v
+++ b/test/snl/formats/verilog/backend/references/test1Test4/top.v
@@ -1,0 +1,15 @@
+module model(input [2:-2] i0, input [-2:2] i1, output [2:-2] o0, output [-2:2] o1);
+endmodule //model
+
+module top();
+wire [2:-2] bus0;
+wire [-2:2] bus1;
+wire [2:-2] bus2;
+wire [-2:2] bus3;
+wire net_0;
+wire net_2;
+
+model instance1(.i0(), .i1(), .o0({net_0, bus0[-2:-2], net_2, bus0[-1:0]}), .o1());
+
+model instance2(.i0(), .i1(), .o0(), .o1());
+endmodule //top


### PR DESCRIPTION
Missing space and comma for scalar nets concatenations.
Associated unit tests added.